### PR TITLE
Add note title to sort field

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -23,7 +23,7 @@ if "pytest" not in sys.modules:
     def open_dialog():
         "Launch the add-poem dialog."
         current_version = aqt.mw.col.get_config("lpcg_model_version", default="none")
-        if not models.LpcgOne.is_at_version(current_version):
+        if not models.AbgOne.is_at_version(current_version):
             showWarning(
                 "Your LPCG note type is out of date and needs to be upgraded "
                 "before you can use LPCG. To upgrade the note type, restart Anki "

--- a/src/gen_notes.py
+++ b/src/gen_notes.py
@@ -259,7 +259,7 @@ def add_notes(col: Any, note_constructor: Callable,
     """
     added = 0
     for line in _poemlines_from_textlines(text, group_lines):
-        n = note_constructor(col, col.models.by_name("LPCG 1.0"))
+        n = note_constructor(col, col.models.by_name("Anki Bible Generator"))
         line.populate_note(n, title, author, tags, context_lines, recite_lines, deck_id)
         col.addNote(n)
         added += 1

--- a/src/lpcg_dialog.py
+++ b/src/lpcg_dialog.py
@@ -181,7 +181,7 @@ class LPCGDialog(QDialog):
             return
         escaped_title = title.replace('"', '\\"')
         if self.mw.col.find_notes(
-            f'"note:{models.LpcgOne.name}" '  # pylint: disable=no-member
+            f'"note:{models.AbgOne.name}" '  # pylint: disable=no-member
             f'"Title:{escaped_title}"'
         ):
             showWarning(
@@ -226,7 +226,7 @@ class LPCGDialog(QDialog):
                 " yet, you can delete the note type in Tools -> Manage"
                 " Note Types and restart Anki to fix this problem."
                 " Otherwise, please add the field back to the note type. ".format(
-                    field=str(e), name=models.LpcgOne.name
+                    field=str(e), name=models.AbgOne.name
                 )
             )  # pylint: disable=no-member
             return

--- a/src/models.py
+++ b/src/models.py
@@ -193,12 +193,11 @@ def upgrade_onethreeoh_to_onefouroh(mod):
         )
 
 
-class LpcgOne(ModelData):
-    class LpcgOneTemplate(TemplateData):
-        name = "LPCG1"
+class AbgOne(ModelData):
+    class AbgOneTemplate(TemplateData):
+        name = "Anki Bible Generator"
         front = """
-            <div class="title">{{Title}} {{Sequence}}</div>
-            {{#Author}}<div class="author">{{Author}}</div>{{/Author}}
+            <div class="title">{{Sequence}}</div>
 
             <br>
 
@@ -211,8 +210,7 @@ class LpcgOne(ModelData):
             </div>
         """
         back = """
-            <div class="title">{{Title}} {{Sequence}}</div>
-            {{#Author}}<div class="author">{{Author}}</div>{{/Author}}
+            <div class="title">{{Sequence}}</div>
 
             <br>
 
@@ -222,9 +220,9 @@ class LpcgOne(ModelData):
             </div>
         """
 
-    name = "LPCG 1.0"
+    name = "Anki Bible Generator"
     fields = ("Line", "Context", "Title", "Author", "Sequence", "Prompt")
-    templates = (LpcgOneTemplate,)
+    templates = (AbgOneTemplate,)
     styling = """
         .card {
             font-family: arial;
@@ -277,7 +275,7 @@ def ensure_note_type() -> None:
     Create or update the LPCG note type as needed.
     """
     assert aqt.mw is not None, "Tried to use models before Anki is initialized!"
-    mod = LpcgOne
+    mod = AbgOne
 
     if not mod.in_collection():
         model_data, new_version = mod.to_model()


### PR DESCRIPTION
**Note that I changed one line without really understanding the code base. It seems to work for me without bugs, but there will be things I haven't thought to test. Please consider this before merging!**

For example, if Hebrews 1 is imported with Title set to "Hebrews 1", the created notes with have Sequence fields "Hebrews 1 &sect;1", "Hebrews 1 &sect;2", et cetera. I decided not to simply use a colon, as the section numbers will go out of sync with the verse numbers if the user decides to split long verses.